### PR TITLE
refactor!: rename `exports` to `$exports`

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ import { loadFile, writeFile } from "magicast";
 
 const mod = await loadFile("config.js");
 
-mod.exports.default.foo.push("b");
+mod.$exports.default.foo.push("b");
 
 await writeFile(_module);
 ```
@@ -75,10 +75,10 @@ import { parseCode, generateCode } from "magicast";
 const mod = parseCode(`export default { }`);
 
 // Ensure foo is an array
-mod.exports.default.foo ||= [];
+mod.$exports.default.foo ||= [];
 // Add a new array member
-mod.exports.default.foo.push("b");
-mod.exports.default.foo.unshift("a");
+mod.$exports.default.foo.push("b");
+mod.$exports.default.foo.unshift("a");
 
 // Generate code
 const { code, map } = generateCode(mod);
@@ -99,7 +99,7 @@ import { parseCode, generateCode } from "magicast";
 
 const mod = parseCode(`export default { }`);
 
-const ast = mod.exports.default.$ast
+const ast = mod.$exports.default.$ast
 // do something with ast
 ```
 
@@ -111,9 +111,9 @@ import { parseCode, generateCode } from "magicast";
 const mod = parseCode(`export default defineConfig({ foo: 'bar' })`);
 
 // Support for both bare object export and `defineConfig` wrapper
-const options = mod.exports.default.$type === 'function-call'
-  ? mod.exports.default.$args[0]
-  : mod.exports.default;
+const options = mod.$exports.default.$type === 'function-call'
+  ? mod.$exports.default.$args[0]
+  : mod.$exports.default;
 
 console.log(options.foo) // bar
 ```

--- a/src/proxy/module.ts
+++ b/src/proxy/module.ts
@@ -13,7 +13,7 @@ export function proxifyModule<T>(ast: ParsedFileNode): ProxifiedModule<T> {
   return {
     $ast: root,
     $type: "module",
-    exports: createExportsProxy(root),
-    imports: createImportsProxy(root),
+    $exports: createExportsProxy(root),
+    $imports: createImportsProxy(root),
   } as any;
 }

--- a/src/proxy/types.ts
+++ b/src/proxy/types.ts
@@ -43,8 +43,8 @@ export type Proxified<T = any> = T extends
   : T;
 
 export interface ProxifiedModule<T = Record<string, unknown>> {
-  exports: Proxified<T>;
-  imports: ProxifiedImportsMap;
+  $exports: Proxified<T>;
+  $imports: ProxifiedImportsMap;
 }
 
 export type ProxifiedImportsMap = Record<string, ProxifiedImportItem> &

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -10,13 +10,13 @@ describe("magicast", () => {
   it("basic object and array", () => {
     const mod = parseCode(`export default { a: 1, b: { c: {} } }`);
 
-    mod.exports.default.a = 2;
+    mod.$exports.default.a = 2;
 
     expect(generate(mod)).toMatchInlineSnapshot(
       '"export default { a: 2, b: { c: {} } };"'
     );
 
-    mod.exports.default.b.c = { d: 3 };
+    mod.$exports.default.b.c = { d: 3 };
 
     expect(generate(mod)).toMatchInlineSnapshot(`
       "export default {
@@ -29,11 +29,11 @@ describe("magicast", () => {
       };"
     `);
 
-    expect(mod.exports.default.b.c.d).toBe(3);
+    expect(mod.$exports.default.b.c.d).toBe(3);
 
-    mod.exports.default.modules ||= [];
+    mod.$exports.default.modules ||= [];
 
-    expect(mod.exports.default.modules.$ast).toBeDefined();
+    expect(mod.$exports.default.modules.$ast).toBeDefined();
 
     expect(generate(mod)).toMatchInlineSnapshot(`
       "export default {
@@ -49,8 +49,8 @@ describe("magicast", () => {
       };"
     `);
 
-    mod.exports.default.modules.push("a");
-    mod.exports.default.modules.unshift({ foo: "bar" });
+    mod.$exports.default.modules.push("a");
+    mod.$exports.default.modules.unshift({ foo: "bar" });
 
     expect(generate(mod)).toMatchInlineSnapshot(`
       "export default {
@@ -71,7 +71,7 @@ describe("magicast", () => {
       };"
     `);
 
-    expect(mod.exports.default).toMatchInlineSnapshot(`
+    expect(mod.$exports.default).toMatchInlineSnapshot(`
       {
         "a": 2,
         "b": {
@@ -88,15 +88,15 @@ describe("magicast", () => {
       }
     `);
 
-    expect(mod.exports.default.modules.$type).toBe("array");
-    expect(mod.exports.default.modules[0].$type).toBe("object");
+    expect(mod.$exports.default.modules.$type).toBe("array");
+    expect(mod.$exports.default.modules[0].$type).toBe("object");
   });
 
   it("mix two configs", () => {
     const mod1 = parseCode(`export default { a: 1 }`);
     const mod2 = parseCode(`export default { b: 2 }`);
 
-    mod1.exports.default.b = mod2.exports.default;
+    mod1.$exports.default.b = mod2.$exports.default;
 
     expect(generate(mod1)).toMatchInlineSnapshot(
       `
@@ -120,10 +120,10 @@ describe("magicast", () => {
       })
     `);
 
-    expect(mod.exports.a.foo).toBe(1);
-    expect(mod.exports.default.$type).toBe("function-call");
-    expect(mod.exports.default.$callee).toBe("defineConfig");
-    expect(mod.exports.default.$args).toMatchInlineSnapshot(`
+    expect(mod.$exports.a.foo).toBe(1);
+    expect(mod.$exports.default.$type).toBe("function-call");
+    expect(mod.$exports.default.$callee).toBe("defineConfig");
+    expect(mod.$exports.default.$args).toMatchInlineSnapshot(`
         [
           {
             "modules": [
@@ -133,7 +133,7 @@ describe("magicast", () => {
         ]
       `);
 
-    const options = mod.exports.default.$args[0];
+    const options = mod.$exports.default.$args[0];
 
     options.modules ||= [];
     options.modules.push("b");
@@ -150,18 +150,18 @@ describe("magicast", () => {
   it("delete property", () => {
     const mod = parseCode(`export default { a: 1, b: [1, { foo: 'bar' }] }`);
 
-    delete mod.exports.default.b[1].foo;
+    delete mod.$exports.default.b[1].foo;
 
     expect(generate(mod)).toMatchInlineSnapshot(
       '"export default { a: 1, b: [1, {}] };"'
     );
 
-    delete mod.exports.default.b[0];
+    delete mod.$exports.default.b[0];
     expect(generate(mod)).toMatchInlineSnapshot(
       '"export default { a: 1, b: [undefined, {}] };"'
     );
 
-    delete mod.exports.default.a;
+    delete mod.$exports.default.a;
     expect(generate(mod)).toMatchInlineSnapshot(`
       "export default {
         b: [undefined, {}],
@@ -172,11 +172,11 @@ describe("magicast", () => {
   it("array operations", () => {
     const mod = parseCode(`export default [1, 2, 3, 4, 5]`);
 
-    expect(mod.exports.default.length).toBe(5);
-    expect(mod.exports.default.includes(5)).toBe(true);
-    expect(mod.exports.default.includes(6)).toBe(false);
+    expect(mod.$exports.default.length).toBe(5);
+    expect(mod.$exports.default.includes(5)).toBe(true);
+    expect(mod.$exports.default.includes(6)).toBe(false);
 
-    const deleted = mod.exports.default.splice(1, 3, { foo: "bar" }, "bar");
+    const deleted = mod.$exports.default.splice(1, 3, { foo: "bar" }, "bar");
 
     expect(deleted).toEqual([2, 3, 4]);
 
@@ -193,10 +193,10 @@ describe("magicast", () => {
     `
     );
 
-    const foundIndex = mod.exports.default.findIndex(
+    const foundIndex = mod.$exports.default.findIndex(
       (item) => item.foo === "bar"
     );
-    const found = mod.exports.default.find((item) => item.foo === "bar");
+    const found = mod.$exports.default.find((item) => item.foo === "bar");
 
     expect(foundIndex).toBe(1);
     expect(found).toMatchInlineSnapshot(`
@@ -209,10 +209,10 @@ describe("magicast", () => {
   it("manipulate exports", () => {
     const mod = parseCode("");
 
-    expect(mod.exports).toMatchInlineSnapshot(`{}`);
+    expect(mod.$exports).toMatchInlineSnapshot(`{}`);
     expect(generate(mod)).toMatchInlineSnapshot('""');
 
-    mod.exports.default = { foo: "1" };
+    mod.$exports.default = { foo: "1" };
 
     expect(generate(mod)).toMatchInlineSnapshot(`
       "export default {
@@ -220,7 +220,7 @@ describe("magicast", () => {
       };"
     `);
 
-    mod.exports.default.foo = 2;
+    mod.$exports.default.foo = 2;
 
     expect(generate(mod)).toMatchInlineSnapshot(`
       "export default {
@@ -228,8 +228,8 @@ describe("magicast", () => {
       };"
     `);
 
-    mod.exports.named ||= [];
-    mod.exports.named.push("a");
+    mod.$exports.named ||= [];
+    mod.$exports.named.push("a");
 
     expect(generate(mod)).toMatchInlineSnapshot(`
       "export default {
@@ -240,13 +240,13 @@ describe("magicast", () => {
     `);
 
     // delete
-    delete mod.exports.default;
+    delete mod.$exports.default;
 
     expect(generate(mod)).toMatchInlineSnapshot(
       '"export const named = [\\"a\\"];"'
     );
 
-    delete mod.exports.named;
+    delete mod.$exports.named;
 
     expect(generate(mod)).toMatchInlineSnapshot('""');
   });
@@ -261,12 +261,12 @@ export default defineConfig({
   foo: []
 })`);
 
-    expect(mod.exports.default.$args[0]).toMatchInlineSnapshot(`
+    expect(mod.$exports.default.$args[0]).toMatchInlineSnapshot(`
       {
         "foo": [],
       }
     `);
-    expect(mod.imports).toMatchInlineSnapshot(`
+    expect(mod.$imports).toMatchInlineSnapshot(`
       {
         "Plugin": {
           "from": "vite",
@@ -291,7 +291,7 @@ export default defineConfig({
       }
     `);
 
-    expect(mod.imports.path).toMatchInlineSnapshot(`
+    expect(mod.$imports.path).toMatchInlineSnapshot(`
       {
         "from": "path",
         "imported": "*",
@@ -299,20 +299,10 @@ export default defineConfig({
       }
     `);
 
-    mod.imports.path.local = "path2";
-    mod.imports.Vue.local = "VuePlugin";
+    mod.$imports.path.local = "path2";
+    mod.$imports.Vue.local = "VuePlugin";
 
-    delete mod.imports.Plugin;
-
-    expect(generate(mod)).toMatchInlineSnapshot(`
-      "import { defineConfig } from \\"vite\\";
-      import VuePlugin from \\"@vitejs/plugin-vue\\";
-      import * as path2 from \\"path\\";
-
-      export default defineConfig({
-        foo: [],
-      });"
-    `);
+    delete mod.$imports.Plugin;
 
     expect(generate(mod)).toMatchInlineSnapshot(`
       "import { defineConfig } from \\"vite\\";
@@ -324,17 +314,27 @@ export default defineConfig({
       });"
     `);
 
-    mod.imports.$add({
+    expect(generate(mod)).toMatchInlineSnapshot(`
+      "import { defineConfig } from \\"vite\\";
+      import VuePlugin from \\"@vitejs/plugin-vue\\";
+      import * as path2 from \\"path\\";
+
+      export default defineConfig({
+        foo: [],
+      });"
+    `);
+
+    mod.$imports.$add({
       from: "foo",
       imported: "default",
       local: "Foo",
     });
-    mod.imports.$add({
+    mod.$imports.$add({
       from: "star",
       imported: "*",
       local: "Star",
     });
-    mod.imports.$add({
+    mod.$imports.$add({
       from: "vite",
       imported: "Good",
     });
@@ -351,7 +351,7 @@ export default defineConfig({
       });"
     `);
 
-    mod.imports.defineConfig.from = "vitest/config";
+    mod.$imports.defineConfig.from = "vitest/config";
 
     expect(generate(mod)).toMatchInlineSnapshot(`
       "import { defineConfig } from \\"vitest/config\\";


### PR DESCRIPTION
Follow up https://github.com/unjs/magicast/pull/11

Created as PR as now I am a bit hesitate about this, as we could consider the `mod` a different type of object. I imagine magicast to work for most of the cases without the need to access dollar sign functions like `$ast` - in that sense `$` can be consider as "Advanced" features. If so, the module object itself does not contains things other than `exports` and `imports`. Probably keep it without `$` make the code more clean?
