### PR TITLE
feat: add `$set`  func to object

### DIFF
--- a/src/proxy/_utils.ts
+++ b/src/proxy/_utils.ts
@@ -27,6 +27,10 @@ export function isValidPropName(name: string) {
   return /^[$A-Z_a-z][\w$]*$/.test(name);
 }
 
+export function isUndef(v: unknown): v is undefined {
+  return v === undefined;
+}
+
 const PROXY_KEY = "__magicast_proxy";
 
 export function literalToAst(value: any, seen = new Set()): ASTNode {

--- a/test/object.test.ts
+++ b/test/object.test.ts
@@ -50,4 +50,37 @@ export default {
       };"
     `);
   });
+
+  it("call $set function", () => {
+    const mod = parseModule(
+      `
+const a = "dog";
+const b = "cat";
+export default {
+  foo: {
+    ['a']: 1,
+    ['a-b']: 2,
+    foo() {}
+  }
+}
+    `.trim()
+    );
+
+    mod.exports.default.foo.$set('a');
+    mod.exports.default.foo.$set('b', 'b');
+
+    expect(generate(mod)).toMatchInlineSnapshot(`
+      "const a = \\"dog\\";
+      const b = \\"cat\\";
+      export default {
+        foo: {
+          [\\"a\\"]: 1,
+          [\\"a-b\\"]: 2,
+          foo() {},
+          a,
+          b: b,
+        },
+      };"
+    `);
+  });
 });


### PR DESCRIPTION
## feature
I added a function to objectProxy that sets a variable value of identifier type for the object.

example:
```ts
const mod = parseModule(`export default {}`)

// export default { a }
mod.exports.default.$set('a')

// export default { b: b }
mod.exports.default.$set('b', 'b')

// export default { c: b }
mod.exports.default.$set('c', 'b')

/**
 * export default {
 *   a,
 *   b: b,
 *   c: b,
 * }
 */
console.log(mod.generateCode()) 
```

## question
I wanna use the feature that I added, but it brings some problems that I don't know how to solve.

1. Can't get value.

```ts
const mod = parseModule(`export default {}`)
mod.exports.default.$set('a')

// find the identifier ast node: { type:  Identifier, name: 'a' }
// log: {}
mod.exports.default.a
```

2. Whether to adapt `{ [a]: a }`.

There are some differences between these two situations.

```ts
// object
const bar = {
  [a]: a
}

// ast
{
  "type": "ObjectProperty",
  "computed": true,
  "method": false,
  "shorthand": false,
  "key": {
    "type": "Identifier",
    "name": "a"
  },
  "value": {
    "type": "Identifier",
    "name": "a"
  }
}
```

```ts
// object
const foo = {
  ["a"]: a
}

// ast
{
  "type": "ObjectProperty",
  "computed": true,
  "method": false,
  "shorthand": false,
  "key": {
    "type": "StringLiteral",
    "value": "a"
  },
  "value": {
    "type": "Identifier",
    "name": "a"
  }
}
```