### PR TITLE
feat: add Vite plugin at a given index

### DIFF
--- a/src/helpers/vite.ts
+++ b/src/helpers/vite.ts
@@ -37,12 +37,17 @@ export interface UpdateVitePluginConfigOptions {
 
 export function addVitePlugin(
   magicast: ProxifiedModule<any>,
-  plugin: AddVitePluginOptions
+  plugin: AddVitePluginOptions,
+  index?: number
 ) {
   const config = getDefaultExportOptions(magicast);
 
+  const insertionIndex = index ?? config.plugins?.length ?? 0;
+
   config.plugins ||= [];
-  config.plugins.push(
+  config.plugins.splice(
+    insertionIndex,
+    0,
     plugin.options
       ? builders.functionCall(plugin.constructor, plugin.options)
       : builders.functionCall(plugin.constructor)

--- a/src/helpers/vite.ts
+++ b/src/helpers/vite.ts
@@ -21,6 +21,12 @@ export interface AddVitePluginOptions {
    * The options of the plugin
    */
   options?: Record<string, any>;
+
+  /**
+   * The index in the plugins array where the plugin should be inserted at.
+   * By default, the plugin is appended to the array.
+   */
+  index?: number;
 }
 
 export interface UpdateVitePluginConfigOptions {
@@ -37,12 +43,11 @@ export interface UpdateVitePluginConfigOptions {
 
 export function addVitePlugin(
   magicast: ProxifiedModule<any>,
-  plugin: AddVitePluginOptions,
-  index?: number
+  plugin: AddVitePluginOptions
 ) {
   const config = getDefaultExportOptions(magicast);
 
-  const insertionIndex = index ?? config.plugins?.length ?? 0;
+  const insertionIndex = plugin.index ?? config.plugins?.length ?? 0;
 
   config.plugins ||= [];
   config.plugins.splice(

--- a/test/helpers/vite.test.ts
+++ b/test/helpers/vite.test.ts
@@ -69,45 +69,32 @@ export default defineConfig({
 
     const mod = parseModule(code);
 
-    addVitePlugin(
-      mod,
-      {
-        from: "@vitejs/plugin-vue",
-        constructor: "vuePlugin",
-        options: {
-          include: [/\\.vue$/, /\.md$/],
-        },
+    addVitePlugin(mod, {
+      from: "@vitejs/plugin-vue",
+      constructor: "vuePlugin",
+      options: {
+        include: [/\\.vue$/, /\.md$/],
       },
-      0 // at the beginning
-    );
+      index: 0, // at the beginning
+    });
 
-    addVitePlugin(
-      mod,
-      {
-        from: "vite-plugin-inspect",
-        constructor: "Inspect",
-        options: {
-          build: true,
-        },
+    addVitePlugin(mod, {
+      from: "vite-plugin-inspect",
+      constructor: "Inspect",
+      options: {
+        build: true,
       },
-      2 // in the middle
-    );
+      index: 2, // in the middle
+    });
 
-    addVitePlugin(
-      mod,
-      {
-        from: "vite-plugin-pwa",
-        imported: "VitePWA",
-        constructor: "VitePWA",
-      },
-      5 // at the end, out of bounds on purpose
-    );
+    addVitePlugin(mod, {
+      from: "vite-plugin-pwa",
+      imported: "VitePWA",
+      constructor: "VitePWA",
+      index: 5, // at the end, out of bounds on purpose
+    });
 
-    const res = generate(mod);
-
-    console.log(res);
-
-    expect(res).toMatchInlineSnapshot(`
+    expect(generate(mod)).toMatchInlineSnapshot(`
       "import { VitePWA } from \\"vite-plugin-pwa\\";
       import Inspect from \\"vite-plugin-inspect\\";
       import vuePlugin from \\"@vitejs/plugin-vue\\";


### PR DESCRIPTION
This PR adds an optional parameter to the `addVitePlugin` helper function to specify an optional index where the plugin should be inserted. This makes it possible to use this helper if a plugin if the plugin to be inserted needs to run first or appear before/after a certain plugin. 
If the index parameter is not specified, the function will append the plugin to the end of the array just like before. 

This PR also adds a test to show the behaviour for inserting plugins at the beggining, middle and end of the array. 

Reason for this change:
I need this feature for our Sentry SDK installation wizard. It's pretty simple to do without a high-level helper but I thought I'd contribute it upstream as well as IMO it would be nice to have out of the box. Feel free to close this if you want to take this API into another direction.

Thanks for taking the time to consider this.