### PR TITLE
fix: support code with `as` and `satisfies`

### DIFF
--- a/src/proxy/proxify.ts
+++ b/src/proxy/proxify.ts
@@ -44,6 +44,11 @@ export function proxify<T>(node: ASTNode, mod?: ProxifiedModule): Proxified<T> {
       proxy = proxifyIdentifier(node);
       break;
     }
+    case "TSAsExpression":
+    case "TSSatisfiesExpression": {
+      proxy = proxify(node.expression, mod) as ProxifiedValue;
+      break;
+    }
     default:
       throw new MagicastError(`Casting "${node.type}" is not supported`, {
         ast: node,

--- a/test/general.test.ts
+++ b/test/general.test.ts
@@ -145,6 +145,54 @@ export const config = {
     `);
   });
 
+  it("satisfies", () => {
+    const mod = parseModule(
+      `export const obj = { foo: 42 } satisfies Record<string, number>;`
+    );
+
+    mod.exports.obj.foo = 100;
+
+    expect(generate(mod)).toMatchInlineSnapshot(
+      '"export const obj = { foo: 100 } satisfies Record<string, number>;"'
+    );
+  });
+
+  it("satisfies 2", () => {
+    const mod = parseModule(`export default {} satisfies {}`);
+
+    mod.exports.default.foo = 100;
+
+    expect(generate(mod)).toMatchInlineSnapshot(`
+      "export default {
+        foo: 100,
+      } satisfies {};"
+    `);
+  });
+
+  it("as", () => {
+    const mod = parseModule(
+      `export const obj = { foo: 42 } as Record<string, number>;`
+    );
+
+    mod.exports.obj.foo = 100;
+
+    expect(generate(mod)).toMatchInlineSnapshot(
+      '"export const obj = { foo: 100 } as Record<string, number>;"'
+    );
+  });
+
+  it("as 2", () => {
+    const mod = parseModule(`export default {} as {}`);
+
+    mod.exports.default.foo = 100;
+
+    expect(generate(mod)).toMatchInlineSnapshot(`
+      "export default {
+        foo: 100,
+      } as {};"
+    `);
+  });
+
   describe("parseExpression", () => {
     it("object", () => {
       const exp = parseExpression<any>("{ a: 1, b: 2 }");


### PR DESCRIPTION
fixes https://github.com/unjs/magicast/issues/36