### PR TITLE
fix(createProxy): trap for the 'in' operator

### DIFF
--- a/src/proxy/_utils.ts
+++ b/src/proxy/_utils.ts
@@ -131,10 +131,10 @@ export function createProxy<T>(
         return propertyDescriptor;
       },
       has(_target: any, key: string | symbol) {
-        if(key in utils) {
-          return true
+        if (key in utils) {
+          return true;
         }
-        return false
+        return false;
       },
       ...handler,
       get(target: any, key: string | symbol, receiver: any) {

--- a/src/proxy/_utils.ts
+++ b/src/proxy/_utils.ts
@@ -130,6 +130,12 @@ export function createProxy<T>(
       getOwnPropertyDescriptor() {
         return propertyDescriptor;
       },
+      has(_target: any, key: string | symbol) {
+        if(key in utils) {
+          return true
+        }
+        return false
+      },
       ...handler,
       get(target: any, key: string | symbol, receiver: any) {
         if (key in utils) {

--- a/test/helpers/nuxt.test.ts
+++ b/test/helpers/nuxt.test.ts
@@ -24,4 +24,34 @@ describe("helpers > nuxt", () => {
       });"
     `);
   });
+
+  it("add module, keep format", () => {
+    const code = `export default defineNuxtConfig({
+      modules: [
+        'foo',
+      ]
+    })`;
+
+    const mod = parseModule(code);
+    addNuxtModule(mod, "@vueuse/nuxt", "vueuse", { hello: "world" });
+    addNuxtModule(mod, "@unocss/nuxt", "unocss", { another: "config" });
+
+    expect(mod.generate().code).toMatchInlineSnapshot(`
+      "export default defineNuxtConfig({
+        modules: [
+          'foo',
+          '@vueuse/nuxt',
+          '@unocss/nuxt'
+        ],
+
+        vueuse: {
+          hello: 'world'
+        },
+
+        unocss: {
+          another: 'config'
+        }
+      })"
+    `);
+  });
 });

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -50,4 +50,14 @@ describe("literalToAst", () => {
     obj.foo = obj;
     expect(() => run(obj)).toThrowError("Can not serialize circular reference");
   });
+
+  describe('makeProxyUtils', () => {
+    it('trap in operator', () => {
+      const mod = parseModule("")
+      const keys = ['$code', '$type', '$ast', '__magicast_proxy']
+      for (const key of keys) {
+        expect(key in mod).toBe(true)
+      }
+    })
+  })
 });

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -51,13 +51,13 @@ describe("literalToAst", () => {
     expect(() => run(obj)).toThrowError("Can not serialize circular reference");
   });
 
-  describe('makeProxyUtils', () => {
-    it('trap in operator', () => {
-      const mod = parseModule("")
-      const keys = ['$code', '$type', '$ast', '__magicast_proxy']
+  describe("makeProxyUtils", () => {
+    it("trap in operator", () => {
+      const mod = parseModule("");
+      const keys = ["$code", "$type", "$ast", "__magicast_proxy"];
       for (const key of keys) {
-        expect(key in mod).toBe(true)
+        expect(key in mod).toBe(true);
       }
-    })
-  })
+    });
+  });
 });


### PR DESCRIPTION
I was looking into #41, (this PR is not intend to solve it) but found code in `src/code.ts` below
```js
const formatOptions =
  options.format === false || !("$code" in node)
    ? {}
    : detectCodeFormat(node.$code, options.format);
```
Even if I does not set options.format to false manually, `"$code" in node` would always get false since the proxy util does not trap the `in` operator.

So I make this PR. Feel free to close this if I get the wrong point.

Thank you!