### PR TITLE
fix: type resolution in node16 environments

### DIFF
--- a/helpers.d.ts
+++ b/helpers.d.ts
@@ -1,1 +1,1 @@
-export * from "./dist/helpers.d";
+export * from "./dist/helpers.d.ts";


### PR DESCRIPTION
https://github.com/unjs/magicast/commit/3251584 introduced a bug in `node16` environments. Line https://github.com/unjs/magicast/blob/325158405720eb6729838ee9ed17eb75599ebaf9/helpers.d.ts#L1 must include the file extension. Thus, `export * from "./dist/helpers.d.ts";