### PR TITLE
fix(helpers): improve deepMergeObject handling case

### DIFF
--- a/src/helpers/deep-merge.ts
+++ b/src/helpers/deep-merge.ts
@@ -3,7 +3,10 @@ import type { Proxified } from "../types";
 export function deepMergeObject(magicast: Proxified<any>, object: any) {
   if (typeof object === "object") {
     for (const key in object) {
-      if (typeof object[key] === "object") {
+      if (
+        typeof magicast[key] === "object" &&
+        typeof object[key] === "object"
+      ) {
         deepMergeObject(magicast[key], object[key]);
       } else {
         magicast[key] = object[key];

--- a/test/object.test.ts
+++ b/test/object.test.ts
@@ -110,7 +110,7 @@ export default {
     };
 
     // Recursively merge existing object with `obj`
-    deepMergeObject(mod, obj);
+    deepMergeObject(mod.exports.default, obj);
 
     expect(generate(mod)).toMatchInlineSnapshot(`
       "export default {


### PR DESCRIPTION
Hello;

Following https://github.com/nuxtlabs/studio-api/issues/708

This adds two tests:

- `recursively create objects`
	- Creates a nested object by setting objects properties by hand recursively
	- This on passes properly ✅

- `recursively merge objects`
	- Tries to merge two objects to get the same result as `recursively create objects` using `deepMergeObject`
	- This one does not pass ❌
	
Thank you for helping!