### PR TITLE
feat: deepMergeObject improvements; NumericLiteral and StringLiteral keys

### DIFF
--- a/src/proxy/object.ts
+++ b/src/proxy/object.ts
@@ -23,7 +23,9 @@ export function proxifyObject<T extends object>(
       }
       if (
         prop.type === "ObjectProperty" &&
-        prop.key.type === "StringLiteral" &&
+        (prop.key.type === "StringLiteral" ||
+          prop.key.type === "NumericLiteral" ||
+          prop.key.type === "BooleanLiteral") &&
         prop.key.value === key
       ) {
         return (prop.value as any).value;
@@ -38,8 +40,13 @@ export function proxifyObject<T extends object>(
     if ("key" in prop && "name" in prop.key) {
       return prop.key.name;
     }
-    if (prop.type === "ObjectProperty" && prop.key.type === "StringLiteral") {
-      return prop.key.value;
+    if (
+      prop.type === "ObjectProperty" &&
+      (prop.key.type === "StringLiteral" ||
+        prop.key.type === "NumericLiteral" ||
+        prop.key.type === "BooleanLiteral")
+    ) {
+      return prop.key.value.toString();
     }
     if (throwError) {
       throw new MagicastError(`Casting "${prop.type}" is not supported`, {

--- a/test/object.test.ts
+++ b/test/object.test.ts
@@ -92,7 +92,9 @@ export default {
       `
 export default {
   foo: {
-  }
+  },
+  100: 10,
+  true: 10
 }
     `.trim()
     );
@@ -107,6 +109,10 @@ export default {
           value: "a",
         },
       },
+
+      100: 20,
+
+      true: 20,
     };
 
     // Recursively merge existing object with `obj`
@@ -117,6 +123,9 @@ export default {
         foo: {
           value: 1,
         },
+
+        100: 20,
+        true: 20,
 
         bar: {
           testValue: {


### PR DESCRIPTION
Hey; this is a follow-up of #62

This also fixes remaining parts of: https://github.com/nuxtlabs/studio-api/issues/730

This adds support for `NumericLiteral` and `BooleanLiteral` keys on `proxifyObject`.

If you run the first commit, you'll see that the test merges two of the same keys into two different ones in the object.

That can have unexpected behavior when generating the code from this.

---

I'm not sure about the fix, but it seem to be getting the expected result without breaking any other test.

It might be worth writing other tests for `proxifyObject` to ensure I did not break any other usage with these changes, could you let me know if you have ideas of such cases?