### PR TITLE
feat(helpers): Handle Vite config objects declared as variables in `addVitePlugin`

### DIFF
--- a/src/helpers/config.ts
+++ b/src/helpers/config.ts
@@ -1,7 +1,69 @@
-import type { ProxifiedModule } from "../types";
+import { Program, VariableDeclarator } from "@babel/types";
+import { generateCode, parseExpression } from "../code";
+import { MagicastError } from "../error";
+import type { Proxified, ProxifiedModule, ProxifiedObject } from "../types";
 
 export function getDefaultExportOptions(magicast: ProxifiedModule<any>) {
-  return magicast.exports.default.$type === "function-call"
-    ? magicast.exports.default.$args[0]
-    : magicast.exports.default;
+  return configFromNode(magicast.exports.default);
+}
+
+/**
+ * Returns the vite config object from a variable declaration thats
+ * exported as the default export.
+ *
+ * Example:
+ *
+ * ```js
+ * const config = {};
+ * export default config;
+ * ```
+ *
+ * @param magicast the module
+ *
+ * @returns an object containing the proxified config object and the
+ *          declaration "parent" to attach the modified config to later.
+ *          If no config declaration is found, undefined is returned.
+ */
+export function getConfigFromVariableDeclaration(
+  magicast: ProxifiedModule<any>
+): {
+  declaration: VariableDeclarator;
+  config: ProxifiedObject<any> | undefined;
+} {
+  if (magicast.exports.default.$type !== "identifier") {
+    throw new MagicastError(
+      `Not supported: Cannot modify this kind of default export (${magicast.exports.default.$type})`
+    );
+  }
+
+  const configDecalarationId = magicast.exports.default.$name;
+
+  for (const node of (magicast.$ast as Program).body) {
+    if (node.type === "VariableDeclaration") {
+      for (const declaration of node.declarations) {
+        if (
+          declaration.id.type === "Identifier" &&
+          declaration.id.name === configDecalarationId &&
+          declaration.init
+        ) {
+          const init = declaration.init;
+
+          const configExpression = parseExpression(generateCode(init).code);
+
+          return {
+            declaration,
+            config: configFromNode(configExpression),
+          };
+        }
+      }
+    }
+  }
+  throw new MagicastError("Couldn't find config declaration");
+}
+
+function configFromNode(node: Proxified<any>): ProxifiedObject<any> {
+  if (node.$type === "function-call") {
+    return node.$args[0];
+  }
+  return node;
 }

--- a/test/helpers/vite.test.ts
+++ b/test/helpers/vite.test.ts
@@ -116,4 +116,69 @@ export default defineConfig({
       });"
     `);
   });
+
+  it("handles default export from identifier (fn call)", () => {
+    const code = `
+      import { defineConfig } from 'vite';
+      import { somePlugin1, somePlugin2 } from 'some-module'
+
+      const config = defineConfig({
+        plugins: [somePlugin1(), somePlugin2()]
+      });
+
+      export default config;
+    `;
+
+    const mod = parseModule(code);
+
+    addVitePlugin(mod, {
+      from: "vite-plugin-pwa",
+      imported: "VitePWA",
+      constructor: "VitePWA",
+    });
+
+    expect(generate(mod)).toMatchInlineSnapshot(`
+      "import { VitePWA } from \\"vite-plugin-pwa\\";
+      import { defineConfig } from \\"vite\\";
+      import { somePlugin1, somePlugin2 } from \\"some-module\\";
+
+      const config = defineConfig({
+        plugins: [somePlugin1(), somePlugin2(), VitePWA()],
+      });
+      
+      export default config;"
+    `);
+  });
+
+  it("handles default export from identifier (object)", () => {
+    const code = `
+      import { somePlugin1, somePlugin2 } from 'some-module'
+
+      const myConfig = {
+        plugins: [somePlugin1(), somePlugin2()]
+      };
+
+      export default myConfig;
+    `;
+
+    const mod = parseModule(code);
+
+    addVitePlugin(mod, {
+      index: 1,
+      from: "vite-plugin-pwa",
+      imported: "VitePWA",
+      constructor: "VitePWA",
+    });
+
+    expect(generate(mod)).toMatchInlineSnapshot(`
+      "import { VitePWA } from \\"vite-plugin-pwa\\";
+      import { somePlugin1, somePlugin2 } from \\"some-module\\";
+
+      const myConfig = {
+        plugins: [somePlugin1(), VitePWA(), somePlugin2()],
+      };
+      
+      export default myConfig;"
+    `);
+  });
 });


### PR DESCRIPTION
### 🔗 Linked issue

This sort of addresses #68 but only for `addVitePlugin` and in a less universal way. Still happy to work on #68 if the proposal is accepted but I'd like to contribute this fix first so that we can unblock our usage of `magicast`. 

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
This PR adds support for handling vite configs that are not directly exported as default objects in `addVitePlugin`. 

Currently, a code snippet like 

```js
// vite.config.js
const config = {
  plugins: [somePlugin()]
}
export default config;
```

causes `addVitePlugin` to throw with 

```
TypeError: 'set' on proxy: trap returned falsish for property 'plugins'
```

With this PR, we take the identifier for the default export (if it exists), look up its declaration and if we find it, modify it. Admittedly, the modification and writing back part of this fix is a little messy. With my limited knowledge of the codebase, I think this is as much as we can do, until we come up with a better, general API for modifying declarations (see #68). Happy to be proven wrong though :) (i might need some guidance in that case to do better). 


### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly. 
       Happy to update the readme but first I'd like to know if this has potential to be merged ;)
