### PR TITLE
fix!: `writeFile` now requires filename 

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ const mod = await loadFile("config.js");
 
 mod.exports.default.foo.push("b");
 
-await writeFile(mod);
+await writeFile(mod, "config.js");
 ```
 
 Updated `config.js`:
@@ -164,7 +164,7 @@ function updateConfig() {
 We also experiment to provide a few high level helpers to make common tasks easier. You could import them from `magicast/helpers`. They might be moved to a separate package in the future.
 
 ```js
-import { 
+import {
   deepMergeObject,
   addNuxtModule,
   addVitePlugin,

--- a/src/code.ts
+++ b/src/code.ts
@@ -78,12 +78,11 @@ export async function loadFile<Exports extends object = any>(
 
 export async function writeFile(
   node: { $ast: ASTNode } | ASTNode,
-  filename?: string,
+  filename: string,
   options?: ParseOptions
 ): Promise<void> {
   const ast = "$ast" in node ? node.$ast : node;
   const { code, map } = generateCode(ast, options);
-  filename = filename || "output.js";
   await fsp.writeFile(filename as string, code);
   if (map) {
     await fsp.writeFile(filename + ".map", map);

--- a/src/code.ts
+++ b/src/code.ts
@@ -79,7 +79,7 @@ export async function loadFile<Exports extends object = any>(
 export async function writeFile(
   node: { $ast: ASTNode } | ASTNode,
   filename: string,
-  options?: ParseOptions
+  options?: ParseOptions,
 ): Promise<void> {
   const ast = "$ast" in node ? node.$ast : node;
   const { code, map } = generateCode(ast, options);

--- a/src/code.ts
+++ b/src/code.ts
@@ -77,13 +77,13 @@ export async function loadFile<Exports extends object = any>(
 }
 
 export async function writeFile(
-  node: { ast: ASTNode } | ASTNode,
+  node: { $ast: ASTNode } | ASTNode,
   filename?: string,
   options?: ParseOptions
 ): Promise<void> {
-  const ast = "ast" in node ? node.ast : node;
+  const ast = "$ast" in node ? node.$ast : node;
   const { code, map } = generateCode(ast, options);
-  filename = filename || (ast as any).name || "output.js";
+  filename = filename || "output.js";
   await fsp.writeFile(filename as string, code);
   if (map) {
     await fsp.writeFile(filename + ".map", map);

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,7 +20,6 @@ export interface Token {
 export interface ParsedFileNode {
   type: "file";
   program: Program;
-  name?: string;
   loc: Loc;
   comments: null | any;
 }

--- a/test/code.test.ts
+++ b/test/code.test.ts
@@ -1,0 +1,50 @@
+import { promises as fsp } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { loadFile, parseModule, writeFile } from "../src";
+
+describe("code", () => {
+  it("should load and parse a file", async () => {
+    const stub = await loadFile("./test/stubs/config.ts");
+
+    expect(stub).toBeDefined();
+    expect(stub.$type).toBe("module");
+    expect(stub.$ast).toBeDefined();
+
+    expect(stub.$code).toMatchInlineSnapshot(`
+    "export default {
+      foo: [\\"a\\"],
+    };
+    "`);
+
+    const mod = parseModule(
+      `
+    export default {
+      foo: ["a"],
+    };
+    `,
+      { sourceFileName: "./test/stubs/config.ts" }
+    );
+
+    expect(stub.exports).toEqual(mod.exports);
+  });
+
+  it("should write file from a module", async () => {
+    const mod = parseModule(
+      `
+    export default {
+      foo: ["a"],
+    };
+    `,
+      { sourceFileName: "./test/stubs/config.ts" }
+    );
+
+    await writeFile(mod, "./test/stubs/config2.ts");
+
+    const stub = await fsp.readFile("./test/stubs/config2.ts", "utf8");
+
+    expect(stub).toMatchInlineSnapshot(`
+    "export default {
+      foo: [\\"a\\"],
+    };"`);
+  });
+});

--- a/test/code.test.ts
+++ b/test/code.test.ts
@@ -22,7 +22,7 @@ describe("code", () => {
       foo: ["a"],
     };
     `,
-      { sourceFileName: "./test/stubs/config.ts" }
+      { sourceFileName: "./test/stubs/config.ts" },
     );
 
     expect(stub.exports).toEqual(mod.exports);
@@ -35,7 +35,7 @@ describe("code", () => {
       foo: ["a"],
     };
     `,
-      { sourceFileName: "./test/stubs/config.ts" }
+      { sourceFileName: "./test/stubs/config.ts" },
     );
 
     await writeFile(mod, "./test/stubs/config2.ts");

--- a/test/stubs/.gitignore
+++ b/test/stubs/.gitignore
@@ -1,0 +1,1 @@
+config2.ts

--- a/test/stubs/config.ts
+++ b/test/stubs/config.ts
@@ -1,0 +1,3 @@
+export default {
+  foo: ["a"],
+};


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
fix #66
close #76

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

This PR solve a type issue and add some tests.

And because `recast`, https://github.com/benjamn/recast/blob/master/lib/parser.ts#L24, does not pass the filename to the parser option, we can't use it as the output filename.

_I'm not sure if how tests are written is the best way to do it, so feel free to change it if you have a better idea._

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
