### PR TITLE
feat(helpers): Handle Vite config declarations with `satisfies` keyword

### DIFF
--- a/src/helpers/config.ts
+++ b/src/helpers/config.ts
@@ -46,9 +46,13 @@ export function getConfigFromVariableDeclaration(
           declaration.id.name === configDecalarationId &&
           declaration.init
         ) {
-          const init = declaration.init;
+          const init =
+            declaration.init.type === "TSSatisfiesExpression"
+              ? declaration.init.expression
+              : declaration.init;
 
-          const configExpression = parseExpression(generateCode(init).code);
+          const code = generateCode(init).code;
+          const configExpression = parseExpression(code);
 
           return {
             declaration,

--- a/src/helpers/vite.ts
+++ b/src/helpers/vite.ts
@@ -135,6 +135,23 @@ function insertPluginIntoVariableDeclarationConfig(
       declaration.init = generateCode(
         builders.functionCall(declaration.init.callee.name, configObject),
       ).code;
+    } else if (declaration.init.type === "TSSatisfiesExpression") {
+      if (declaration.init.expression.type === "ObjectExpression") {
+        // @ts-ignore this works despite the type error because of recast
+        declaration.init.expression = generateCode(configObject).code;
+      }
+      if (
+        declaration.init.expression.type === "CallExpression" &&
+        declaration.init.expression.callee.type === "Identifier"
+      ) {
+        // @ts-ignore this works despite the type error because of recast
+        declaration.init.expression = generateCode(
+          builders.functionCall(
+            declaration.init.expression.callee.name,
+            configObject,
+          ),
+        ).code;
+      }
     }
   }
 }

--- a/test/helpers/vite.test.ts
+++ b/test/helpers/vite.test.ts
@@ -181,4 +181,76 @@ export default defineConfig({
       export default myConfig;"
     `);
   });
+
+  it("handles default export from identifier (object with satisfies)", async () => {
+    const code = `
+      import { somePlugin1, somePlugin2 } from 'some-module'
+
+      import type { UserConfig } from 'vite';
+
+      const myConfig = {
+        plugins: [somePlugin1(), somePlugin2()]
+      } satisfies UserConfig;
+
+      export default myConfig;
+    `;
+
+    const mod = parseModule(code);
+
+    addVitePlugin(mod, {
+      index: 1,
+      from: "vite-plugin-pwa",
+      imported: "VitePWA",
+      constructor: "VitePWA",
+    });
+
+    expect(await generate(mod)).toMatchInlineSnapshot(`
+      "import { VitePWA } from \\"vite-plugin-pwa\\";
+      import { somePlugin1, somePlugin2 } from \\"some-module\\";
+      
+      import type { UserConfig } from \\"vite\\";
+
+      const myConfig = {
+        plugins: [somePlugin1(), VitePWA(), somePlugin2()],
+      } satisfies UserConfig;
+
+      export default myConfig;"
+    `);
+  });
+
+  it("handles default export from identifier (function with satisfies)", async () => {
+    const code = `
+      import { somePlugin1, somePlugin2 } from 'some-module'
+
+      import type { UserConfig } from 'vite';
+
+      const myConfig = defineConfig({
+        plugins: [somePlugin1(), somePlugin2()]
+      }) satisfies UserConfig;
+
+      export default myConfig;
+    `;
+
+    const mod = parseModule(code);
+
+    addVitePlugin(mod, {
+      index: 1,
+      from: "vite-plugin-pwa",
+      imported: "VitePWA",
+      constructor: "VitePWA",
+    });
+
+    expect(await generate(mod)).toMatchInlineSnapshot(`
+      "import { VitePWA } from \\"vite-plugin-pwa\\";
+      import { somePlugin1, somePlugin2 } from \\"some-module\\";
+      
+      import type { UserConfig } from \\"vite\\";
+
+      const myConfig = defineConfig({
+        plugins: [somePlugin1(), VitePWA(), somePlugin2()],
+      }) satisfies UserConfig;
+
+      export default myConfig;"
+    `);
+  });
 });


### PR DESCRIPTION
### 🔗 Linked issue

Still relevant for https://github.com/unjs/magicast/issues/68

fixes https://github.com/getsentry/sentry-wizard/issues/445

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

This PR adds support for the `satisfies` keyword when it's used in Vite configs. Specifically for the case, when a config object is declared as a variable (with satisfies) before it's exported:

```typescript
import { somePlugin1, somePlugin2 } from 'some-module'

import type { UserConfig } from 'vite';

const myConfig = defineConfig({
  plugins: [somePlugin1(), somePlugin2()]
}) satisfies UserConfig;

export default myConfig;
```

I also added support for using satisfies in conjuction with `defineConfig` but I'd argue this is pretty unlikely to be used, so happy to remove if reviewers would prefer that.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
