### PR TITLE
fix: unable to get value using `NumericLiteral` or `BooleanLiteral` type keys

### DIFF
--- a/src/proxy/object.ts
+++ b/src/proxy/object.ts
@@ -26,7 +26,7 @@ export function proxifyObject<T extends object>(
         (prop.key.type === "StringLiteral" ||
           prop.key.type === "NumericLiteral" ||
           prop.key.type === "BooleanLiteral") &&
-        prop.key.value === key
+        prop.key.value.toString() === key
       ) {
         return (prop.value as any).value;
       }

--- a/test/object.test.ts
+++ b/test/object.test.ts
@@ -11,7 +11,9 @@ export default {
   foo: {
     ['a']: 1,
     ['a-b']: 2,
-    foo() {}
+    foo() {},
+    1: 3,
+    [true]: 4,
   }
 }
     `.trim(),
@@ -19,11 +21,15 @@ export default {
 
     expect(mod.exports.default.foo.a).toBe(1);
     expect(mod.exports.default.foo["a-b"]).toBe(2);
+    expect(mod.exports.default.foo[1]).toBe(3);
+    expect(mod.exports.default.foo.true).toBe(4);
     expect(Object.keys(mod.exports.default.foo)).toMatchInlineSnapshot(`
       [
         "a",
         "a-b",
         "foo",
+        "1",
+        "true",
       ]
     `);
 
@@ -34,6 +40,8 @@ export default {
         "a",
         "a-b",
         "foo",
+        "1",
+        "true",
         "a-b-c",
       ]
     `);
@@ -46,6 +54,8 @@ export default {
           [\\"a\\"]: 1,
           [\\"a-b\\"]: \\"updated\\",
           foo() {},
+          1: 3,
+          [true]: 4,
           \\"a-b-c\\": 3,
         },
       };"


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

https://github.com/unjs/magicast/issues/90

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Resolves https://github.com/unjs/magicast/issues/90


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
