### PR TITLE
fix: quoted properties of `ObjectExpression` not in exports proxy

### DIFF
--- a/src/proxy/object.ts
+++ b/src/proxy/object.ts
@@ -28,7 +28,7 @@ export function proxifyObject<T extends object>(
           prop.key.type === "BooleanLiteral") &&
         prop.key.value.toString() === key
       ) {
-        return (prop.value as any).value;
+        return (prop.value as any).value || prop.value;
       }
     }
   };

--- a/src/proxy/object.ts
+++ b/src/proxy/object.ts
@@ -28,7 +28,7 @@ export function proxifyObject<T extends object>(
           prop.key.type === "BooleanLiteral") &&
         prop.key.value.toString() === key
       ) {
-        return (prop.value as any).value || prop.value;
+        return (prop.value as any).value ?? prop.value;
       }
     }
   };

--- a/test/object.test.ts
+++ b/test/object.test.ts
@@ -14,6 +14,8 @@ export default {
     foo() {},
     1: 3,
     [true]: 4,
+    "c": { key: 5 },
+    'd': { key: 6 },
   }
 }
     `.trim(),
@@ -23,6 +25,8 @@ export default {
     expect(mod.exports.default.foo["a-b"]).toBe(2);
     expect(mod.exports.default.foo[1]).toBe(3);
     expect(mod.exports.default.foo.true).toBe(4);
+    expect(mod.exports.default.foo.c?.key).toBe(5);
+    expect(mod.exports.default.foo.d?.key).toBe(6);
     expect(Object.keys(mod.exports.default.foo)).toMatchInlineSnapshot(`
       [
         "a",
@@ -30,6 +34,8 @@ export default {
         "foo",
         "1",
         "true",
+        "c",
+        "d",
       ]
     `);
 
@@ -42,6 +48,8 @@ export default {
         "foo",
         "1",
         "true",
+        "c",
+        "d",
         "a-b-c",
       ]
     `);
@@ -56,6 +64,8 @@ export default {
           foo() {},
           1: 3,
           [true]: 4,
+          c: { key: 5 },
+          d: { key: 6 },
           \\"a-b-c\\": 3,
         },
       };"


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

- Fixes #93

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

When traversing the `c` of following:

```js
export default {
  foo: {
    "c": { key: 5 },
    'd': { key: 6 },
  }
}
```

https://github.com/unjs/magicast/blob/32be90efe6be8036088c0a6c39c740f3f0efb13a/src/proxy/object.ts#L31

```js
> prop.value.value
undefined

> prop.value
Node {
  type: 'ObjectExpression',
  start: 35,
  end: 45,
  loc: SourceLocation { ... },
  properties: [
    Node {
      type: 'ObjectProperty',
      start: 37,
      end: 43,
      loc: [SourceLocation],
      method: false,
      key: [Node],
      computed: false,
      shorthand: false,
      value: [Node]
    }
  ]
}
```

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
