### PR TITLE
feat: support logical and member expression

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "release": "pnpm run test run && changelogen --release && npm publish && git push --follow-tags",
     "test": "vitest",
     "test:build": "TEST_BUILD=true vitest",
-    "test:full": "pnpm run test --run && pnpm run build && pnpm run test:build--run"
+    "test:full": "pnpm run test --run && pnpm run build && pnpm run test:build --run"
   },
   "dependencies": {
     "@babel/parser": "^7.24.1",

--- a/src/proxy/logical-expression.ts
+++ b/src/proxy/logical-expression.ts
@@ -1,0 +1,19 @@
+import type { ASTNode, ProxifiedLogicalExpression } from "../types";
+import { MagicastError } from "../error";
+import { createProxy } from "./_utils";
+
+export function proxifyLogicalExpression(
+  node: ASTNode,
+): ProxifiedLogicalExpression {
+  if (node.type !== "LogicalExpression") {
+    throw new MagicastError("Not a logical expression");
+  }
+
+  return createProxy(
+    node,
+    {
+      $type: "logicalExpression",
+    },
+    {},
+  ) as ProxifiedLogicalExpression;
+}

--- a/src/proxy/member-expression.ts
+++ b/src/proxy/member-expression.ts
@@ -1,0 +1,19 @@
+import type { ASTNode, ProxifiedMemberExpression } from "../types";
+import { MagicastError } from "../error";
+import { createProxy } from "./_utils";
+
+export function proxifyMemberExpression(
+  node: ASTNode,
+): ProxifiedMemberExpression {
+  if (node.type !== "MemberExpression") {
+    throw new MagicastError("Not a member expression");
+  }
+
+  return createProxy(
+    node,
+    {
+      $type: "memberExpression",
+    },
+    {},
+  ) as ProxifiedMemberExpression;
+}

--- a/src/proxy/proxify.ts
+++ b/src/proxy/proxify.ts
@@ -7,6 +7,8 @@ import { proxifyArrowFunctionExpression } from "./arrow-function-expression";
 import { proxifyObject } from "./object";
 import { proxifyNewExpression } from "./new-expression";
 import { proxifyIdentifier } from "./identifier";
+import { proxifyLogicalExpression } from "./logical-expression";
+import { proxifyMemberExpression } from "./member-expression";
 import { LITERALS_AST, LITERALS_TYPEOF } from "./_utils";
 
 const _cache = new WeakMap<ASTNode, any>();
@@ -47,6 +49,14 @@ export function proxify<T>(node: ASTNode, mod?: ProxifiedModule): Proxified<T> {
     }
     case "Identifier": {
       proxy = proxifyIdentifier(node);
+      break;
+    }
+    case "LogicalExpression": {
+      proxy = proxifyLogicalExpression(node);
+      break;
+    }
+    case "MemberExpression": {
+      proxy = proxifyMemberExpression(node);
       break;
     }
     case "TSAsExpression":

--- a/src/proxy/types.ts
+++ b/src/proxy/types.ts
@@ -48,6 +48,14 @@ export type ProxifiedIdentifier = ProxyBase & {
   $name: string;
 };
 
+export type ProxifiedLogicalExpression = ProxyBase & {
+  $type: "logicalExpression";
+};
+
+export type ProxifiedMemberExpression = ProxyBase & {
+  $type: "memberExpression";
+};
+
 export type Proxified<T = any> = T extends
   | number
   | string
@@ -107,6 +115,8 @@ export type ProxifiedValue =
   | ProxifiedFunctionCall
   | ProxifiedNewExpression
   | ProxifiedIdentifier
+  | ProxifiedLogicalExpression
+  | ProxifiedMemberExpression
   | ProxifiedObject
   | ProxifiedModule
   | ProxifiedImportsMap

--- a/test/builders/raw.test.ts
+++ b/test/builders/raw.test.ts
@@ -40,4 +40,26 @@ describe("builders/raw", () => {
       };"
     `);
   });
+
+  it("logical expression", async () => {
+    const expression = builders.raw("foo || bar");
+    expect(expression.$type).toBe("logicalExpression");
+    const mod = parseModule("");
+    mod.exports.a = expression;
+
+    expect(await generate(mod)).toMatchInlineSnapshot(`
+      "export const a = foo || bar;"
+    `);
+  });
+
+  it("member expression", async () => {
+    const expression = builders.raw("foo.bar");
+    expect(expression.$type).toBe("memberExpression");
+    const mod = parseModule("");
+    mod.exports.a = expression;
+
+    expect(await generate(mod)).toMatchInlineSnapshot(`
+      "export const a = foo.bar;"
+    `);
+  });
 });


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

N/A

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR adds support for logical and member expression, allowing for that kind of code modification with `builder.raw()` (which would have thrown a `MagicastError` before)

```diff
+ import { foo, bar } as config from "./config.json";

  export const a = {
+   bar: config.foo || config.bar
  }
```

I'm by far not an AST expert so I'm not sure if my changes cover it all. Also I'm not sure if this kind of node support is welcome/within the scope of Magicast, so let me know if not, no big deal ☺️

On another note, I feel like there's a pattern here, maybe we want to support other node types like conditional expressions (`foo ? bar : baz`) with some kind of generic proxy instead for "readonly" kind of node. Feel free to nudge me towards the direction that fits better the project!
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Thanks!

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
