### PR TITLE
feat: add `$prepend` and `$append` APIs to `imports`

### DIFF
--- a/src/helpers/vite.ts
+++ b/src/helpers/vite.ts
@@ -61,7 +61,7 @@ export function addVitePlugin(
     insertPluginIntoConfig(plugin, config);
   }
 
-  magicast.imports.$add({
+  magicast.imports.$prepend({
     from: plugin.from,
     local: plugin.constructor,
     imported: plugin.imported || "default",

--- a/src/proxy/types.ts
+++ b/src/proxy/types.ts
@@ -91,7 +91,10 @@ export type ProxifiedModule<T extends object = Record<string, any>> =
 export type ProxifiedImportsMap = Record<string, ProxifiedImportItem> &
   ProxyBase & {
     $type: "imports";
+    /** @deprecated Use `$prepend` instead  */
     $add: (item: ImportItemInput) => void;
+    $prepend: (item: ImportItemInput) => void;
+    $append: (item: ImportItemInput) => void;
     $items: ProxifiedImportItem[];
   };
 

--- a/test/function-call.test.ts
+++ b/test/function-call.test.ts
@@ -44,7 +44,7 @@ describe("function-calls", () => {
     const installVuePlugin = (mod: ProxifiedModule<any>) => {
       // Inject export default if not exists
       if (!mod.exports.default) {
-        mod.imports.$add({
+        mod.imports.$prepend({
           imported: "defineConfig",
           from: "vite",
         });
@@ -58,7 +58,7 @@ describe("function-calls", () => {
           : mod.exports.default;
 
       // Inject vue plugin import
-      mod.imports.$add({
+      mod.imports.$prepend({
         imported: "default",
         local: "vuePlugin",
         from: "@vitejs/plugin-vue",

--- a/test/imports.test.ts
+++ b/test/imports.test.ts
@@ -84,27 +84,44 @@ foo: []
       });"
     `);
 
-    mod.imports.$add({
+    mod.imports.$prepend({
       from: "foo",
       imported: "default",
       local: "Foo",
     });
-    mod.imports.$add({
+    mod.imports.$prepend({
       from: "star",
       imported: "*",
       local: "Star",
     });
-    mod.imports.$add({
+    mod.imports.$prepend({
       from: "vite",
       imported: "Good",
+    });
+    mod.imports.$append({
+      from: "append-foo",
+      imported: "default",
+      local: "AppendFoo",
+    });
+    mod.imports.$append({
+      from: "append-star",
+      imported: "*",
+      local: "AppendStar",
+    });
+    mod.imports.$append({
+      from: "vite",
+      imported: "AppendGood",
     });
 
     expect(await generate(mod)).toMatchInlineSnapshot(`
       "import * as Star from "star";
       import Foo from "foo";
-      import { defineConfig, Good } from "vite";
+      import { defineConfig, Good, AppendGood } from "vite";
       import VuePlugin from "@vitejs/plugin-vue";
       import * as path2 from "path";
+
+      import AppendFoo from "append-foo";
+      import * as AppendStar from "append-star";
 
       export default defineConfig({
         foo: [],
@@ -117,9 +134,12 @@ foo: []
       "import { defineConfig } from "vitest/config";
       import * as Star from "star";
       import Foo from "foo";
-      import { Good } from "vite";
+      import { Good, AppendGood } from "vite";
       import VuePlugin from "@vitejs/plugin-vue";
       import * as path2 from "path";
+
+      import AppendFoo from "append-foo";
+      import * as AppendStar from "append-star";
 
       export default defineConfig({
         foo: [],


### PR DESCRIPTION
fix https://github.com/unjs/magicast/issues/122

Add `$prepend` and `$append` APIs to `imports`. Deprecate `$add` as it does the same as `$prepend`.

The test snapshot should show that `$append` will append after the last import now, and it creates a new line after the last import. I think that's recast behaviour as adding new properties to objects also tend to create new lines.
