### PR TITLE
fix: respect useSemi: false when generating new imports

### DIFF
--- a/src/code.ts
+++ b/src/code.ts
@@ -8,7 +8,7 @@ import {
   ProxifiedModule,
 } from "./types";
 import { proxifyModule } from "./proxy/module";
-import { detectCodeFormat } from "./format";
+import { detectCodeFormat, applyFormatToCode } from "./format";
 import { proxify } from "./proxy/proxify";
 
 const b = types.builders;
@@ -64,10 +64,15 @@ export function generateCode(
       ? {}
       : detectCodeFormat(node.$code, options.format);
 
-  const { code, map } = print(ast, {
+  const { code: printedCode, map } = print(ast, {
     ...options,
     ...formatOptions,
   });
+
+  const code =
+    formatOptions.useSemi === false
+      ? applyFormatToCode(printedCode, formatOptions)
+      : printedCode;
 
   return { code, map };
 }

--- a/src/format.ts
+++ b/src/format.ts
@@ -126,3 +126,13 @@ export function detectCodeFormat(
     ...userStyles,
   };
 }
+
+export function applyFormatToCode(
+  code: string,
+  format: CodeFormatOptions,
+): string {
+  if (format.useSemi === false) {
+    return code.replace(/^(import\b[^\n]*);$/gm, "$1");
+  }
+  return code;
+}

--- a/test/imports.test.ts
+++ b/test/imports.test.ts
@@ -146,4 +146,16 @@ foo: []
       });"
     `);
   });
+
+  it("respects useSemi: false for new imports", () => {
+    const mod = parseModule("export default {}");
+    mod.imports.VitePWA = { imported: "VitePWA", from: "vite-plugin-pwa" };
+
+    const { code } = mod.generate({ format: { useSemi: false } });
+
+    expect(code).toMatchInlineSnapshot(`
+      "import {VitePWA} from "vite-plugin-pwa"
+      export default {}"
+    `);
+  });
 });


### PR DESCRIPTION
## Summary

- Recast always appends semicolons to programmatic `ImportDeclaration` nodes
- When `useSemi: false` (explicit or auto-detected), strip trailing semicolons from import lines after printing

## Example

```js
const mod = parseModule("export default {}");
mod.imports.VitePWA = { imported: "VitePWA", from: "vite-plugin-pwa" };

generateCode(mod, { format: { useSemi: false } }).code;
// import {VitePWA} from "vite-plugin-pwa"
// export default {}
```

Fixes #116

## Test plan

- [x] Added regression test in `test/imports.test.ts`
- [x] `pnpm exec vitest run` — 71 passing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Code generation now supports a formatting option to omit trailing semicolons from import statements, enabling developers to align generated output with their preferred code style.

* **Tests**
  * Added test coverage verifying the new semicolon formatting option works correctly for generated import statements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unjs/magicast/pull/162?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->