### PR TITLE
fix: parse comment-only strings in builders.raw

### DIFF
--- a/src/code.ts
+++ b/src/code.ts
@@ -13,6 +13,11 @@ import { proxify } from "./proxy/proxify";
 
 const b = types.builders;
 
+function isCommentOnly(code: string): boolean {
+  const trimmed = code.trim();
+  return /^\/\*[\s\S]*\*\/$/.test(trimmed) || /^\/\/[^\n]*$/.test(trimmed);
+}
+
 export function parseModule<Exports extends object = any>(
   code: string,
   options?: ParseOptions,
@@ -28,6 +33,25 @@ export function parseExpression<T>(
   code: string,
   options?: ParseOptions,
 ): Proxified<T> {
+  if (isCommentOnly(code)) {
+    const root: ParsedFileNode = parse(`${code}\n0`, {
+      parser: options?.parser || getBabelParser(),
+      ...options,
+    });
+    let body: ASTNode = root.program.body[0];
+    if (body.type === "ExpressionStatement") {
+      body = body.expression;
+    }
+
+    const mod = {
+      $ast: root,
+      $code: `${code}\n0`,
+      $type: "module",
+    } as any as ProxifiedModule;
+
+    return proxify(body, mod);
+  }
+
   const root: ParsedFileNode = parse("(" + code + ")", {
     parser: options?.parser || getBabelParser(),
     ...options,

--- a/test/builders/raw.test.ts
+++ b/test/builders/raw.test.ts
@@ -62,4 +62,14 @@ describe("builders/raw", () => {
       "export const a = foo.bar;"
     `);
   });
+
+  it("block comment", () => {
+    expect(() => builders.raw("/** foo */")).not.toThrow();
+    expect(builders.raw("/** foo */")).toBe(0);
+  });
+
+  it("line comment", () => {
+    expect(() => builders.raw("// bar")).not.toThrow();
+    expect(builders.raw("// bar")).toBe(0);
+  });
 });


### PR DESCRIPTION
## Summary

- Detect comment-only input in `parseExpression` / `builders.raw`
- Parse via a tiny module (`comment\n0`) instead of parenthesized expression parsing, which treats leading `/` as a regex

## Example

```js
builders.raw("/** foo */"); // was SyntaxError, now returns 0
builders.raw("// bar");     // was SyntaxError, now returns 0
```

Fixes #129

## Test plan

- [x] Added block and line comment cases in `test/builders/raw.test.ts`
- [x] `pnpm exec vitest run` — 72 passing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The raw builder now handles code inputs that consist entirely of comments. Previously, passing code containing only block or line comments would result in an error. This limitation has been resolved, and such inputs are now processed successfully.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unjs/magicast/pull/163?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->