### PR TITLE
fix: handle standalone comments in builders.raw

### DIFF
--- a/src/code.ts
+++ b/src/code.ts
@@ -33,9 +33,8 @@ export function parseExpression<T>(
   // expression position as a regex literal, causing a SyntaxError. Detect this
   // case and prepend `null` so the comment is parsed as a trailing remark on a
   // null literal instead.
-  const isStandaloneComment = /^\s*(?:\/\*[\s\S]*?\*\/|\/\/[^\n]*)\s*$/.test(
-    code,
-  );
+  const isStandaloneComment =
+    /^\s*(?:\/\*[\s\S]*?\*\/|\/\/[^\n\r\u2028\u2029]*)\s*$/.test(code);
 
   const parseCode = isStandaloneComment ? code + "\nnull" : "(" + code + ")";
 

--- a/src/code.ts
+++ b/src/code.ts
@@ -10,6 +10,7 @@ import {
 import { proxifyModule } from "./proxy/module";
 import { detectCodeFormat } from "./format";
 import { proxify } from "./proxy/proxify";
+import { makeProxyUtils } from "./proxy/_utils";
 
 const b = types.builders;
 
@@ -28,16 +29,43 @@ export function parseExpression<T>(
   code: string,
   options?: ParseOptions,
 ): Proxified<T> {
-  const root: ParsedFileNode = parse("(" + code + ")", {
+  // Wrapping a standalone comment in "()" makes Babel's parser interpret "/" in
+  // expression position as a regex literal, causing a SyntaxError. Detect this
+  // case and prepend `null` so the comment is parsed as a trailing remark on a
+  // null literal instead.
+  const isStandaloneComment = /^\s*(?:\/\*[\s\S]*?\*\/|\/\/[^\n]*)\s*$/.test(
+    code,
+  );
+
+  const parseCode = isStandaloneComment ? code + "\nnull" : "(" + code + ")";
+
+  const root: ParsedFileNode = parse(parseCode, {
     parser: options?.parser || getBabelParser(),
     ...options,
   });
   let body: ASTNode = root.program.body[0];
   if (body.type === "ExpressionStatement") {
-    body = body.expression;
+    const expr = (body as any).expression;
+    if (isStandaloneComment && (body as any).comments?.length) {
+      // Transfer comments from ExpressionStatement to the expression node so
+      // they survive when the node is embedded into another AST.
+      expr.comments = (body as any).comments;
+      delete (body as any).comments;
+    }
+    body = expr;
   }
-  if (body.extra?.parenthesized) {
-    body.extra.parenthesized = false;
+  if ((body as any).extra?.parenthesized) {
+    (body as any).extra.parenthesized = false;
+  }
+
+  if (isStandaloneComment) {
+    // proxify() for NullLiteral returns JS `undefined` (NullLiteral has no
+    // .value in Babel's AST), which loses the comment. Return a proxy with
+    // $ast pointing to the expression directly so that literalToAst() emits
+    // it — including the attached comment — when the node is inserted.
+    return makeProxyUtils(body, {
+      $type: "comment",
+    }) as unknown as Proxified<T>;
   }
 
   const mod = {

--- a/test/builders/raw.test.ts
+++ b/test/builders/raw.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { builders, parseModule } from "magicast";
+import { builders, generateCode, parseModule } from "magicast";
 import { generate } from "../_utils";
 
 describe("builders/raw", () => {
@@ -61,5 +61,29 @@ describe("builders/raw", () => {
     expect(await generate(mod)).toMatchInlineSnapshot(`
       "export const a = foo.bar;"
     `);
+  });
+
+  it("block comment does not throw and is a comment proxy", () => {
+    const result = builders.raw("/** foo */");
+    expect(result).toBeDefined();
+    expect((result as any).$type).toBe("comment");
+  });
+
+  it("line comment does not throw and is a comment proxy", () => {
+    const result = builders.raw("// line comment");
+    expect(result).toBeDefined();
+    expect((result as any).$type).toBe("comment");
+  });
+
+  it("block comment preserves comment text when inserted into array", () => {
+    const mod = parseModule("export default [];");
+    (mod.exports.default as any[]).push(builders.raw("/** foo */"));
+    expect(generateCode(mod).code).toContain("/** foo */");
+  });
+
+  it("jsdoc comment preserves text when inserted into array", () => {
+    const mod = parseModule("export default [];");
+    (mod.exports.default as any[]).push(builders.raw("/** @type {string} */"));
+    expect(generateCode(mod).code).toContain("/** @type {string} */");
   });
 });


### PR DESCRIPTION
### 🔗 Linked issue

Fixes #129

### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📖 Description

`builders.raw('/** foo */')` threw a `SyntaxError: Unterminated regular expression` (or `Unexpected token`) because `parseExpression` wraps the input in `("...")` before passing to Babel. When the input is a block/line comment, Babel sees `/` in expression position and tries to lex a regex instead of a comment, then fails.

**Root cause:** `(/** foo */)` → Babel sees `(` then `/` → starts regex parsing → `**` or end-of-input → error.

**Fix:** Detect standalone comment strings (matching `^\s*(\/\*...\*\/|\/\/...)\s*$`) and parse them with a null literal suffix (`code + "\nnull"`) instead of parentheses. The comment is transferred from the `ExpressionStatement` to the `NullLiteral` expression node, and a proxy with `$type: "comment"` is returned (with `$ast` pointing to the null node). `literalToAst()` already follows the `$ast` reference via the `__magicast_proxy` marker, so inserting the result into any AST emits the comment correctly.

```js
// Before (throws)
builders.raw('/** foo */')    // SyntaxError: Unterminated regular expression
builders.raw('// line comment') // SyntaxError

// After (works)
const comment = builders.raw('/** foo */')
// comment.$type === 'comment'
// comment.$ast.type === 'NullLiteral' (with /** foo */ as leading comment)

const mod = parseModule('export default [];')
mod.exports.default.push(comment)
generateCode(mod).code
// → 'export default [/** foo */\nnull];'
```

Note: since a JS comment is not a valid standalone expression, the emitted output includes a `null` literal carrying the comment. This is a necessary trade-off — there is no way to represent a comment without an adjacent node in the AST.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed parsing errors when standalone block or line comments were interpreted incorrectly.
  * Improved comment handling so comments remain intact when inserted into expressions and generated code.
  * Preserved comment text, including JSDoc and type annotations, during code generation.

* **Tests**
  * Added coverage confirming block and line comments are accepted and retained without errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->