### PR TITLE
fix: preserve inner comment when adding a property to an empty object

### DIFF
--- a/src/proxy/object.ts
+++ b/src/proxy/object.ts
@@ -96,6 +96,19 @@ export function proxifyObject<T extends object>(
         isValidPropName(key) ? b.identifier(key) : b.stringLiteral(key),
         value as any,
       );
+      // Babel attaches comments inside an otherwise-empty object (e.g.
+      // `{ /* keep me */ }`) as `innerComments`, which recast's printer
+      // ignores when the node is reprinted after being modified. Move them
+      // onto the first inserted property as leading comments so they survive.
+      const innerComments = (node as any).innerComments;
+      if (innerComments?.length) {
+        (newProp as any).comments = innerComments.map((comment: any) => ({
+          ...comment,
+          leading: true,
+          trailing: false,
+        }));
+        (node as any).innerComments = [];
+      }
       node.properties.push(newProp as any);
     }
   };

--- a/test/object.test.ts
+++ b/test/object.test.ts
@@ -339,4 +339,37 @@ export default {
     expect("a" in proxy).toBe(true);
     expect("c" in proxy).toBe(false);
   });
+
+  it("preserves inner comment when adding a property to an empty object", async () => {
+    const mod = parseModule(
+      `
+export default {
+  /* inner comment */
+}
+    `.trim(),
+    );
+
+    mod.exports.default.foo = 1;
+
+    expect(await generate(mod)).toMatchInlineSnapshot(`
+      "export default {
+        /* inner comment */
+        foo: 1,
+      };"
+    `);
+  });
+
+  it("preserves inner line comment when adding a property to an empty object", async () => {
+    const mod = parseModule(
+      `
+export default {
+  // inner comment
+}
+    `.trim(),
+    );
+
+    mod.exports.default.foo = 1;
+
+    expect(await generate(mod)).toContain("// inner comment");
+  });
 });


### PR DESCRIPTION
## Problem

Comments placed inside an otherwise-empty object literal are lost as soon as a property is added to that object.

```ts
import { parseModule, generateCode } from "magicast";

const mod = parseModule(`
export default {
  /* inner comment */
}
`);

mod.exports.default.foo = 1;

console.log(generateCode(mod).code);
```

Actual:

```ts
export default {
  foo: 1
};
```

Expected — the inner comment is preserved:

```ts
export default {
  /* inner comment */
  foo: 1
};
```

## Cause

`@babel/parser` attaches comments that sit inside an empty object as `innerComments` on the `ObjectExpression` node. recast's printer only looks at `node.comments` (entries flagged `leading`/`trailing`) and ignores `innerComments`. While the node is untouched recast reuses the original source verbatim, so the comment survives; once a property is added the node is reprinted and the comment is dropped.

## Fix

When inserting the **first** property into an object that still carries `innerComments`, move those comments onto the new property as leading comments so recast emits them. Objects that already have properties, and objects without inner comments, are unaffected.

Both block (`/* */`) and line (`//`) inner comments are covered by the added tests.

Fixes #33

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where comments on empty objects were inadvertently lost during code transformation and generation. Comments now persist correctly through object modifications and appear properly in the final code output.

* **Tests**
  * Added comprehensive test cases to ensure proper comment preservation when transforming empty objects, covering both block and line comments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->