### PR TITLE
fix(imports): keep proxy source in sync

### DIFF
--- a/src/proxy/imports.ts
+++ b/src/proxy/imports.ts
@@ -83,13 +83,14 @@ export function createImportProxy(
         if (declaration) {
           // TODO: insert after the last import maybe?
           declaration.specifiers.push(specifier as any);
+          node = declaration;
         } else {
-          root.body.unshift(
-            b.importDeclaration(
-              [specifier as any],
-              b.stringLiteral(value),
-            ) as any,
+          const newDeclaration = b.importDeclaration(
+            [specifier as any],
+            b.stringLiteral(value),
           );
+          root.body.unshift(newDeclaration as any);
+          node = newDeclaration as any;
         }
       },
       toJSON() {

--- a/test/imports.test.ts
+++ b/test/imports.test.ts
@@ -146,4 +146,14 @@ foo: []
       });"
     `);
   });
+
+  it("keeps an import proxy in sync after moving its source", () => {
+    const mod = parseModule(`import { foo } from "a"`);
+    const item = mod.imports.foo;
+
+    item.from = "b";
+
+    expect(item.from).toBe("b");
+    expect(mod.imports.foo.from).toBe("b");
+  });
 });


### PR DESCRIPTION
## Problem

After `mod.imports.foo.from = "b"` moves an import declaration, the existing import proxy and the same item retrieved from `mod.imports` still report the old source (`"a"`). The generated code is updated, but subsequent reads of the public `from` property are stale.

## Fix

Update the cached proxy's captured declaration whenever the specifier is moved to an existing or newly created import declaration.

## Tests

- `pnpm exec vitest run test/imports.test.ts` — passed
- `pnpm test --run` — 17 files, 77 tests passed
- `pnpm test --coverage` — 17 files, 77 tests passed
- `pnpm build` — passed
- `pnpm run test:build --run` — 17 files, 77 tests passed
- `pnpm exec eslint --cache .` — passed
- `pnpm exec prettier --check src/proxy/imports.ts test/imports.test.ts` — passed

## Compatibility

The change keeps the existing AST move and generated output intact while making the already returned proxy reflect its new declaration. No public API shape or dependency changes are introduced. The repository-wide typecheck and full lint command retain unrelated pre-existing failures documented in the audit.

## Related issue

Independent reproduction; no existing issue or competing PR was found for this stale proxy state.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed import source changes so moved imports now correctly report their new source.
  - Updated import metadata to stay synchronized after relocating an import.

- **Tests**
  - Added coverage verifying that import proxies and module import listings reflect the updated source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->