### PR TITLE
fix(array): support variadic push/unshift and open-ended splice

### DIFF
--- a/src/proxy/array.ts
+++ b/src/proxy/array.ts
@@ -11,24 +11,29 @@ export function proxifyArrayElements<T extends any[]>(
   const utils = makeProxyUtils(node, {
     $type: "array",
     // Mutator methods - they modify the underlying AST
-    push(value: any) {
-      elements.push(literalToAst(value) as any);
+    push(...values: any[]) {
+      return elements.push(...values.map((v) => literalToAst(v) as any));
     },
     pop() {
       return proxify(elements.pop() as any, mod);
     },
-    unshift(value: any) {
-      elements.unshift(literalToAst(value) as any);
+    unshift(...values: any[]) {
+      return elements.unshift(...values.map((v) => literalToAst(v) as any));
     },
     shift() {
       return proxify(elements.shift() as any, mod);
     },
-    splice(start: number, deleteCount: number, ...items: any[]) {
-      const deleted = elements.splice(
-        start,
-        deleteCount,
-        ...items.map((n) => literalToAst(n)),
-      );
+    splice(start: number, ...rest: [number?, ...any[]]) {
+      // `deleteCount` is only defaulted to 0 when it is passed explicitly;
+      // omitting it removes every element from `start` onwards.
+      const deleted =
+        rest.length === 0
+          ? elements.splice(start)
+          : elements.splice(
+              start,
+              rest[0] as number,
+              ...rest.slice(1).map((n) => literalToAst(n)),
+            );
       return deleted.map((n) => proxify(n as any, mod));
     },
     toJSON() {

--- a/test/array.test.ts
+++ b/test/array.test.ts
@@ -94,4 +94,29 @@ describe("array", () => {
     expect(fullArray.length).toBe(3);
     expect(fullArray[2].id).toBe(3);
   });
+
+  it("push and unshift accept multiple values", async () => {
+    const mod = parseModule<{ default: string[] }>(`export default ["c"]`);
+    const arr = mod.exports.default;
+
+    expect(arr.push("d", "e")).toBe(3);
+    expect(arr.unshift("a", "b")).toBe(5);
+
+    expect([...arr]).toEqual(["a", "b", "c", "d", "e"]);
+    expect(await generate(mod)).toMatchInlineSnapshot(
+      `"export default ["a", "b", "c", "d", "e"];"`,
+    );
+  });
+
+  it("splice without a deleteCount removes the rest of the array", async () => {
+    const mod = parseModule<{ default: number[] }>(
+      `export default [1, 2, 3, 4]`,
+    );
+
+    const deleted = mod.exports.default.splice(1);
+
+    expect(deleted).toEqual([2, 3, 4]);
+    expect(mod.exports.default.length).toBe(1);
+    expect(await generate(mod)).toMatchInlineSnapshot(`"export default [1];"`);
+  });
 });


### PR DESCRIPTION
The proxified array mutators diverge from `Array.prototype` in three ways that fail silently.

### 1. `push` / `unshift` drop every argument after the first

```js
const mod = parseModule(`export default ["c"]`);
mod.exports.default.push("d", "e");
generateCode(mod).code; // export default ["c", "d"];  <- "e" is gone
```

Both were declared as `push(value: any)` and forwarded only that one value. The extra arguments are dropped without any error, so the caller has no way to notice.

### 2. `push` / `unshift` return `undefined`

Native `push`/`unshift` return the new length. Both here returned `undefined`, so a common `if (arr.push(x) > 1)` style check silently misbehaves.

### 3. `splice(start)` deletes nothing

```js
const mod = parseModule(`export default [1, 2, 3, 4]`);
mod.exports.default.splice(1); // returns [], array unchanged
```

`deleteCount` was a required positional parameter, so omitting it passed `undefined` to the underlying `Array#splice`, which coerces it to `0`. Native semantics are "delete through the end of the array". The fix only defaults `deleteCount` when it is actually passed, leaving the existing 2+ argument behaviour (covered by the current test) untouched.

### Changes

- `push` / `unshift` are variadic, map every argument through `literalToAst`, and return the new length.
- `splice` distinguishes an omitted `deleteCount` from an explicit one.
- Two regression tests in `test/array.test.ts`. Both fail on `main` (`expected undefined to be 3`, `expected [] to deeply equal [2, 3, 4]`) and pass with this change.

### Validation

- `pnpm vitest run` — 78 tests / 17 files pass
- `TEST_BUILD=true pnpm vitest run` after `pnpm build` — 78 pass
- `eslint` and `prettier -c` clean on both touched files

No public type changes: `ProxifiedArray` maps over `T`, so `push`/`unshift`/`splice` were already typed from the native array signatures — this only brings the runtime in line with them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Array operations now support adding multiple values with `push` and `unshift`.
  - `splice` now supports omitting the deletion count to remove all elements from the starting position.
  - `splice` supports optional replacement items.

- **Tests**
  - Added coverage for multi-value insertion and extended `splice` behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->