### PR TITLE
fix: preserve tab indentation when modifying modules

### DIFF
--- a/src/code.ts
+++ b/src/code.ts
@@ -22,6 +22,8 @@ export function parseModule<Exports extends object = any>(
   const node: ParsedFileNode = parse(code, {
     parser: options?.parser || getBabelParser(),
     ...options,
+    // Parse and print must agree on the width of existing tab indentation.
+    tabWidth: options?.tabWidth ?? detectCodeFormat(code).tabWidth,
   });
   return proxifyModule(node, code);
 }

--- a/test/format.test.ts
+++ b/test/format.test.ts
@@ -1,5 +1,6 @@
 import type { CodeFormatOptions } from "magicast";
 import { detectCodeFormat, generateCode, parseModule } from "magicast";
+import { addVitePlugin } from "magicast/helpers";
 import { describe, expect, it } from "vitest";
 
 describe("format", () => {
@@ -104,4 +105,18 @@ describe("format", () => {
     expect(detectedFormat.quote).toBe("single");
     expect(detectedFormat.useTabs).toBe(false);
   });
+});
+
+it.each([undefined, 4])("preserves tab indentation with tabWidth %s", (tabWidth) => {
+  const mod = parseModule(
+    "import { defineConfig } from 'vite'\n\nexport default defineConfig({\n\tplugins: []\n})\n",
+    tabWidth === undefined ? undefined : { tabWidth },
+  );
+  addVitePlugin(mod, {
+    from: "@vitejs/plugin-vue",
+    constructor: "vue",
+    options: { owo: true },
+  });
+  const code = generateCode(mod, { format: { tabWidth } }).code;
+  expect(code).toContain("\n\tplugins: [vue({\n\t\towo: true\n\t})]");
 });

--- a/vendor/recast/lib/lines.ts
+++ b/vendor/recast/lib/lines.ts
@@ -619,12 +619,18 @@ export class Lines {
 
       if (prevInfo) {
         const info = linesOrNull.infos[0];
-        const indent = new Array(info.indent + 1).join(" ");
+        const isEmpty = prevInfo.sliceStart === prevInfo.sliceEnd;
+        const indent = isEmpty ? "" : new Array(info.indent + 1).join(" ");
         const prevLine = infos.length;
         const prevColumn =
           Math.max(prevInfo.indent, 0) +
           prevInfo.sliceEnd -
           prevInfo.sliceStart;
+
+        if (isEmpty) {
+          // Keep leading indentation as metadata so toString can emit tabs.
+          prevInfo.indent = Math.max(prevInfo.indent, 0) + Math.max(info.indent, 0);
+        }
 
         prevInfo.line =
           prevInfo.line.slice(0, prevInfo.sliceEnd) +


### PR DESCRIPTION
Fixes #34.

Adding a Vite plugin to a config indented with one tab currently changes `plugins` to four tabs and emits a mixture of tabs and spaces for the plugin options. The issue's reproducer now keeps one tab for `plugins` and two tabs for the nested option.

There are two causes:

- Recast parses with its default tab width, while `generateCode()` prints using the detected width. Pass the detected width to `parseModule()` too, preserving an explicit parser override.
- The vendored Recast line concatenation turns appended indentation into literal spaces, even when the prefix contains no code. Keep that leading indentation in the line metadata so the printer can render it as tabs. Inline spacing and the source-map offset calculation retain their existing behavior.

The regression exercises `addVitePlugin()` with both detected indentation and an explicit tab width of 4. Both cases fail on the unchanged base.

Validation:

- `pnpm lint` passes on the clean source tree.
- `pnpm exec vitest run --coverage`: 85 tests pass.
- `pnpm build` and `pnpm run test:build --run`: build succeeds; 85 tests pass against the built output.
- `pnpm exec tsc --noEmit --skipLibCheck` passes. Unmodified `pnpm typecheck` reports the same 7 errors in dependency declarations on both the base and this branch.

AI assistance: OpenAI Codex assisted with diagnosis, implementation, and testing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed formatting so tab-indented source code preserves its existing tab width when modules are parsed, modified, and regenerated.
  - Improved output when adding Vite plugins, including cases with automatic or explicitly configured tab widths.

- **Tests**
  - Added coverage confirming tab indentation remains intact across supported tab-width configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->